### PR TITLE
feat(linux/editor): Docker packaging, Linux fixes, Mermaid lightbox, Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 
 # mobile (Capacitor) build output + native build artifacts
 dist-mobile/
+dist-linux/
 ios/App/Pods/
 ios/App/App/public/
 ios/App/build/

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,0 +1,45 @@
+FROM node:18-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    ruby \
+    ruby-dev \
+    gcc \
+    make \
+    dpkg \
+    fakeroot \
+    libarchive-tools \
+    unzip \
+    imagemagick \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    libpangocairo-1.0-0 \
+    libgtk-3-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN gem install fpm --no-document
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+ENV ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+ENV ELECTRON_BUILDER_BINARIES_MIRROR=https://npmmirror.com/mirrors/electron-builder-binaries/
+ENV npm_config_registry=https://registry.npmmirror.com
+
+RUN npm ci --prefer-offline 2>&1 | tail -5
+
+COPY . .
+
+CMD ["bash", "/app/docker-entrypoint.sh"]

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,0 +1,24 @@
+FROM node:18-bookworm
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates \
+    wine wine32 wine64 \
+    nsis \
+    osslsigncode \
+    libarchive-tools unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+ENV ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+ENV ELECTRON_BUILDER_BINARIES_MIRROR=https://npmmirror.com/mirrors/electron-builder-binaries/
+ENV npm_config_registry=https://registry.npmmirror.com
+
+RUN npm ci --prefer-offline 2>&1 | tail -5
+
+COPY . .
+
+CMD ["bash", "/app/docker-entrypoint-win.sh"]

--- a/build/installer-resources/after-install.sh
+++ b/build/installer-resources/after-install.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+cat > /usr/share/mime/packages/horsemd.xml << 'XMLEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/markdown">
+    <comment>Markdown document</comment>
+    <comment xml:lang="zh_CN">Markdown 文档</comment>
+    <glob pattern="*.md"/>
+    <glob pattern="*.markdown"/>
+    <glob pattern="*.mdx"/>
+  </mime-type>
+</mime-info>
+XMLEOF
+
+update-mime-database /usr/share/mime || true
+
+ICONS_DIR="/opt/HorseMD/resources/linux-icons/hicolor"
+if [ -d "$ICONS_DIR" ]; then
+  cp -rn "$ICONS_DIR"/* /usr/share/icons/hicolor/
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache /usr/share/icons/hicolor || true
+fi
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database /usr/share/applications || true
+fi

--- a/build/installer-resources/after-remove.sh
+++ b/build/installer-resources/after-remove.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Remove our MIME type file
+rm -f /usr/share/mime/packages/horsemd.xml
+
+# Update MIME database to remove our types
+if [ -f /usr/share/mime/packages ]; then
+  update-mime-database /usr/share/mime || true
+fi
+
+# Update desktop database
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database /usr/share/applications || true
+fi

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# docker-build.sh — 用 Docker 编译 HorseMD Linux deb 包
+#
+# 用法：
+#   ./docker-build.sh            # 构建镜像并编译，产物输出到 ./dist-linux/
+#   ./docker-build.sh --no-cache  # 强制不使用缓存重新构建镜像
+#
+# 前提：已安装并启动 Docker
+
+set -euo pipefail
+
+IMAGE_NAME="horsemd-builder"
+OUTPUT_DIR="$(pwd)/dist-linux"
+DOCKERFILE="Dockerfile.deb"
+
+# 解析参数
+NO_CACHE=""
+for arg in "$@"; do
+  case $arg in
+    --no-cache) NO_CACHE="--no-cache" ;;
+    *) echo "未知参数: $arg"; exit 1 ;;
+  esac
+done
+
+echo "================================================"
+echo "  HorseMD Linux deb 构建"
+echo "================================================"
+echo "  镜像名称：$IMAGE_NAME"
+echo "  产物目录：$OUTPUT_DIR"
+echo ""
+
+# 确保输出目录存在
+mkdir -p "$OUTPUT_DIR"
+
+# Step 1: 构建 Docker 镜像
+echo ">>> Step 1/2: 构建 Docker 镜像（首次较慢，后续有缓存）..."
+docker build \
+  $NO_CACHE \
+  -f "$DOCKERFILE" \
+  -t "$IMAGE_NAME" \
+  .
+
+echo ""
+echo ">>> Step 2/2: 在容器内编译并打包 deb..."
+# 挂载 dist-linux 目录，容器内构建完成后将 dist/ 内容复制进去
+docker run --rm \
+  --name horsemd-build-run \
+  -v "$OUTPUT_DIR:/output" \
+  "$IMAGE_NAME"
+
+echo ""
+echo "================================================"
+echo "  构建完成！产物在：$OUTPUT_DIR"
+echo "================================================"
+ls -lh "$OUTPUT_DIR"/*.deb 2>/dev/null || echo "  ⚠️  未找到 .deb 文件，请检查构建日志"

--- a/docker-entrypoint-win.sh
+++ b/docker-entrypoint-win.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+npm run build
+
+npx electron-builder --win nsis --x64 \
+  --config.win.artifactName='${productName}-Setup-${version}.exe' \
+  --config.directories.output=/output
+
+echo 'win built:' && ls -lh /output/*.exe

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+convert icon.png -resize 512x512 build/icon-linux.png
+
+for size in 16 24 32 48 64 128 256; do
+  d="build/linux-icons/hicolor/${size}x${size}/apps"
+  mkdir -p "$d"
+  convert build/icon-linux.png -resize "${size}x${size}" "$d/horsemd.png"
+done
+
+npm run build
+
+npx electron-builder --linux deb --x64 \
+  --config.linux.artifactName='${productName}-${version}-linux-amd64.deb' \
+  --config.directories.output=/output
+
+echo 'deb built:' && ls -lh /output/*.deb

--- a/package.json
+++ b/package.json
@@ -58,6 +58,13 @@
     "files": [
       "out/**/*"
     ],
+    "extraResources": [
+      {
+        "from": "build/linux-icons",
+        "to": "linux-icons",
+        "filter": ["**/*"]
+      }
+    ],
     "icon": "build/icon.ico",
     "publish": [
       {
@@ -125,6 +132,47 @@
       "installerIcon": "build/icon.ico",
       "uninstallerIcon": "build/icon.ico",
       "include": "build/installer.nsh"
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "deb",
+          "arch": ["x64"]
+        }
+      ],
+      "icon": "build/icon-linux.png",
+      "category": "Office",
+      "executableName": "horsemd",
+      "mimeTypes": ["text/markdown"],
+      "desktop": {
+        "Name": "HorseMD",
+        "Comment": "Warm, modern Markdown editor",
+        "Categories": "Office;TextEditor;",
+        "MimeType": "text/markdown"
+      },
+      "fileAssociations": [
+        {
+          "ext": "md",
+          "name": "Markdown Document",
+          "role": "Editor"
+        },
+        {
+          "ext": "markdown",
+          "name": "Markdown Document",
+          "role": "Editor"
+        },
+        {
+          "ext": "mdx",
+          "name": "Markdown Document",
+          "role": "Editor"
+        }
+      ]
+    },
+    "deb": {
+      "maintainer": "mini_md <horsemd@yangsir.net>",
+      "depends": ["libgtk-3-0", "libnotify4", "libnss3", "libxss1", "libxtst6", "xdg-utils", "libatspi2.0-0", "libsecret-1-0"],
+      "afterInstall": "build/installer-resources/after-install.sh",
+      "afterRemove": "build/installer-resources/after-remove.sh"
     }
   }
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -155,6 +155,9 @@ function sendToRenderer(channel, payload) {
 }
 
 function createWindow() {
+  const iconPath = process.platform === 'linux' && app.isPackaged
+    ? join(process.resourcesPath, 'linux-icons/hicolor/256x256/apps/horsemd.png')
+    : undefined
   mainWindow = new BrowserWindow({
     width: 1280,
     height: 820,
@@ -162,6 +165,7 @@ function createWindow() {
     minHeight: 480,
     show: false,
     backgroundColor: '#1a1b20',
+    ...(iconPath ? { icon: iconPath } : {}),
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'hidden',
     // macOS: place the traffic lights at a fixed spot so the renderer can
     // reserve a matching gap (see `.app.is-mac` rules in app.css). y centers the
@@ -246,6 +250,7 @@ app.on('open-file', (event, path) => {
 })
 
 app.whenReady().then(() => {
+  if (process.platform === 'linux') app.setName('HorseMD')
   ensureThemesDir()
   buildMenu()
   createWindow()
@@ -897,7 +902,8 @@ function buildMenu() {
         { label: 'Toggle Theme', accelerator: 'CmdOrCtrl+Shift+T', click: menuCmd('toggleTheme') },
         { type: 'separator' },
         { role: 'resetZoom' },
-        { role: 'zoomIn' },
+        { role: 'zoomIn', accelerator: 'CmdOrCtrl+=' },
+        { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', click: () => { mainWindow?.webContents.setZoomFactor(Math.min(5, mainWindow.webContents.getZoomFactor() + 0.1)) }, visible: false },
         { role: 'zoomOut' },
         { type: 'separator' },
         { role: 'togglefullscreen' },

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webFrame } from 'electron'
 
 // Subscribe to a main→renderer channel; returns an unsubscribe function.
 const on = (channel) => (cb) => {
@@ -80,6 +80,9 @@ const api = {
   onFileChanged: on('file:changed'),
   onWindowMaximized: on('window:maximized'),
   onAppCloseRequest: on('app-close-request'),
+
+  setZoomFactor: (f) => webFrame.setZoomFactor(f),
+  getZoomFactor: () => webFrame.getZoomFactor(),
 
   platform: process.platform,
 

--- a/src/renderer/src/components/Editor.jsx
+++ b/src/renderer/src/components/Editor.jsx
@@ -349,6 +349,9 @@ export default function Editor({
   const [level, setLevel] = useState(null) // { label, kind, top, left } or null
   // Lightbox: the image src currently shown enlarged, or null.
   const [zoom, setZoom] = useState(null)
+  const lightboxScaleRef = useRef(1)
+  const lightboxContentRef = useRef(null)
+  const lightboxTranslateRef = useRef({ x: 0, y: 0 })
   // False until Crepe has parsed and rendered the document — drives the loading
   // skeleton. Only large documents (which actually take a moment to render) show
   // it, so small files never flash a placeholder.
@@ -914,7 +917,7 @@ export default function Editor({
           const now = e.timeStamp || Date.now()
           if (lastImgClick.src === src && now - lastImgClick.at < 350) {
             e.preventDefault()
-            setZoom(src)
+            setZoom({ type: 'img', src })
             lastImgClick = { src: null, at: 0 }
           } else {
             lastImgClick = { src, at: now }
@@ -953,8 +956,19 @@ export default function Editor({
           fireToast(tRef.current('code.copied'))
         }
 
+        const onMermaidClick = (e) => {
+          const svg = e.target.closest?.('.milkdown-code-block .preview svg')
+          if (!svg || !view.dom.contains(svg)) return
+          const clone = svg.cloneNode(true)
+          clone.removeAttribute('width')
+          clone.removeAttribute('height')
+          clone.style.cssText = ''
+          setZoom({ type: 'svg', html: clone.outerHTML })
+        }
+
         view.dom.addEventListener('click', onLinkClick, true)
         view.dom.addEventListener('click', onImgClick, true)
+        view.dom.addEventListener('click', onMermaidClick, true)
         view.dom.addEventListener('click', onCaptionBtn)
         view.dom.addEventListener('click', onCopyBtn, true)
         view.dom.addEventListener('copy', onCopy, true)
@@ -976,6 +990,7 @@ export default function Editor({
         )
         cleanups.push(() => view.dom.removeEventListener('click', onLinkClick, true))
         cleanups.push(() => view.dom.removeEventListener('click', onImgClick, true))
+        cleanups.push(() => view.dom.removeEventListener('click', onMermaidClick, true))
         cleanups.push(() => view.dom.removeEventListener('click', onCaptionBtn))
         cleanups.push(() => view.dom.removeEventListener('click', onCopyBtn, true))
         cleanups.push(() => view.dom.removeEventListener('copy', onCopy, true))
@@ -1306,12 +1321,67 @@ export default function Editor({
 
   // Close the image lightbox on Escape.
   useEffect(() => {
-    if (!zoom) return
+    if (!zoom) {
+      lightboxScaleRef.current = 1
+      lightboxTranslateRef.current = { x: 0, y: 0 }
+      return
+    }
     const onKey = (e) => {
       if (e.key === 'Escape') setZoom(null)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
+  }, [zoom])
+
+  // Ctrl+wheel inside the lightbox scales the content element only.
+  // Runs capture-phase so it fires before (and blocks) the global wheel handler.
+  useEffect(() => {
+    if (!zoom) return
+    const applyTransform = (el) => {
+      const { x, y } = lightboxTranslateRef.current
+      el.style.transform = `translate(${x}px, ${y}px) scale(${lightboxScaleRef.current})`
+      el.style.transformOrigin = 'center center'
+    }
+    const onWheel = (e) => {
+      if (!e.ctrlKey) return
+      e.preventDefault()
+      e.stopPropagation()
+      const el = lightboxContentRef.current
+      if (!el) return
+      const delta = e.deltaY < 0 ? 0.1 : -0.1
+      lightboxScaleRef.current = Math.min(10, Math.max(0.2, lightboxScaleRef.current + delta))
+      applyTransform(el)
+    }
+    const onMouseDown = (e) => {
+      const el = lightboxContentRef.current
+      if (!el || !el.contains(e.target) || e.button !== 0) return
+      e.preventDefault()
+      el.style.cursor = 'grabbing'
+      const startX = e.clientX - lightboxTranslateRef.current.x
+      const startY = e.clientY - lightboxTranslateRef.current.y
+      let dragged = false
+      const onMove = (ev) => {
+        dragged = true
+        lightboxTranslateRef.current = { x: ev.clientX - startX, y: ev.clientY - startY }
+        applyTransform(el)
+      }
+      const onUp = () => {
+        el.style.cursor = 'grab'
+        window.removeEventListener('mousemove', onMove)
+        window.removeEventListener('mouseup', onUp)
+        if (dragged) {
+          window.addEventListener('click', (ev) => ev.stopPropagation(), { capture: true, once: true })
+        }
+      }
+      window.addEventListener('mousemove', onMove)
+      window.addEventListener('mouseup', onUp)
+    }
+    window.addEventListener('wheel', onWheel, { capture: true, passive: false })
+    window.addEventListener('mousedown', onMouseDown)
+    return () => {
+      window.removeEventListener('wheel', onWheel, { capture: true, passive: false })
+      window.removeEventListener('mousedown', onMouseDown)
+    }
   }, [zoom])
 
   // The floating bar and context menu reuse the same conversion path as the
@@ -1385,7 +1455,10 @@ export default function Editor({
           role="dialog"
           aria-modal="true"
         >
-          <img src={zoom} alt="" />
+          {zoom.type === 'svg'
+            ? <div ref={lightboxContentRef} className="hm-lightbox-svg" dangerouslySetInnerHTML={{ __html: zoom.html }} onClick={(e) => e.stopPropagation()} />
+            : <img ref={lightboxContentRef} src={zoom.src} alt="" onClick={(e) => e.stopPropagation()} />
+          }
           <button
             className="hm-lightbox-close"
             title={t('lightbox.close')}

--- a/src/renderer/src/lib/menuHandlers.js
+++ b/src/renderer/src/lib/menuHandlers.js
@@ -198,6 +198,28 @@ export function useGlobalKeys({
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)
   }, [handlers])
+
+  // Ctrl+wheel and touchpad pinch-to-zoom. Both generate a wheel event with
+  // ctrlKey=true in Electron (the OS maps pinch gestures to synthetic Ctrl+wheel).
+  // webFrame.setZoomFactor is the correct renderer-side API; it keeps in sync with
+  // the Electron menu's zoom state (same underlying zoom level).
+  useEffect(() => {
+    if (!window.api?.setZoomFactor) return
+    const STEP = 0.1
+    const MIN = 0.5
+    const MAX = 3.0
+    const onWheel = (e) => {
+      if (!e.ctrlKey) return
+      e.preventDefault()
+      const cur = window.api.getZoomFactor()
+      const next = e.deltaY < 0
+        ? Math.min(MAX, Math.round((cur + STEP) * 10) / 10)
+        : Math.max(MIN, Math.round((cur - STEP) * 10) / 10)
+      window.api.setZoomFactor(next)
+    }
+    window.addEventListener('wheel', onWheel, { passive: false })
+    return () => window.removeEventListener('wheel', onWheel, { passive: false })
+  }, [])
 }
 
 // Command-palette list (titles localized via t; run dispatches via handlers).

--- a/src/renderer/src/styles/app.css
+++ b/src/renderer/src/styles/app.css
@@ -1836,6 +1836,7 @@ body.hm-full-width .editor-skeleton {
 .hm-image-lightbox img {
   max-width: 90vw;
   max-height: 90vh;
+  min-width: min(600px, 90vw);
   object-fit: contain;
   border-radius: 6px;
   box-shadow: 0 12px 48px rgba(0, 0, 0, 0.5);
@@ -1856,6 +1857,29 @@ body.hm-full-width .editor-skeleton {
 }
 .hm-lightbox-close:hover { background: rgba(255, 255, 255, 0.24); }
 @keyframes hmLightboxFade { from { opacity: 0; } to { opacity: 1; } }
+
+.hm-lightbox-svg {
+  max-width: 90vw;
+  max-height: 90vh;
+  min-width: min(760px, 90vw);
+  min-height: min(500px, 80vh);
+  overflow: auto;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.5);
+  padding: 24px;
+  cursor: grab;
+  transform-origin: center center;
+}
+.hm-image-lightbox img {
+  cursor: grab;
+}
+.hm-lightbox-svg svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+}
 
 /* Block-level hint: a small, quiet tag beside the caret's line naming the
    current block (H1…H6 / 正文). Non-interactive — purely an at-a-glance cue.


### PR DESCRIPTION
## 概述

本 PR 包含四个方向的改动：Linux deb 打包流水线、Linux 运行时修复、Mermaid 流程图查看体验、Windows NSIS 打包流水线。

---

## 1. Docker Linux deb 打包流水线

**痛点**：Linux deb 包需要在 Linux 环境下构建，macOS/Windows 开发者无法直接打包。

用 Docker 隔离构建环境，在任意平台一键输出 `.deb`：

```bash
./docker-build.sh          # 构建镜像并打包，产物输出到 ./dist-linux/
./docker-build.sh --no-cache
```

- `Dockerfile.deb` — `node:18-bookworm` + ImageMagick + fpm；npmmirror 加速
- `docker-entrypoint.sh` — 生成全尺寸图标 (16–512px) → vite build → electron-builder
- `docker-build.sh` — 宿主机一键脚本

---

## 2. Linux 运行时修复（`package.json` + `src/main/index.js`）

**痛点 1 — 任务栏图标空白**：安装后应用图标显示为空白方块。根因：`package.json` 中 `name` 为 `"horse"`，Electron 默认 WM_CLASS 就是 `horse`，与 `.desktop` 里的 `StartupWMClass=HorseMD` 不匹配，桌面环境无法关联图标。修复：`app.setName('HorseMD')` 使 WM_CLASS 与 `.desktop` 对齐；`BrowserWindow` 传入 256px PNG icon。

**痛点 2 — .md 文件无法关联**：安装后双击 `.md` 文件不会用 HorseMD 打开。根因：`.desktop` 缺少 `MimeType`，无 MIME XML，postinst 未更新数据库。修复：`afterInstall` 脚本写入 `/usr/share/mime/packages/horsemd.xml`，注册 `text/markdown`，更新 mime/desktop/icon 数据库；多尺寸图标 (16–256px) 打包进 `extraResources` 并在安装时复制到 hicolor。

**痛点 3 — Ctrl++ 放大无效**：`Ctrl+-` 能缩小但 `Ctrl++` 没有响应。根因：Linux 上 Electron `role: 'zoomIn'` 默认只绑 `Ctrl+=`，不绑 `Ctrl++`（Shift+=）。修复：加隐藏菜单项绑定 `CmdOrCtrl+Plus`；preload 暴露 `webFrame` zoom API；renderer 监听 `Ctrl+wheel` 和触摸板捏合手势。

---

## 3. Mermaid 流程图全屏查看（`Editor.jsx` + `app.css`）

**痛点**：复杂流程图（节点多的 flowchart、sequenceDiagram、erDiagram）在编辑器列宽内渲染后节点密集、文字极小，完全看不清。切到源码模式无法直观理解图结构，没有任何方式放大查看。

新增交互：
- **点击流程图** → 弹出全屏灯箱，默认尺寸 min 760×500px，最大 90vw/90vh
- **Ctrl+滚轮 / 触摸板捏合** → 在灯箱内缩放 SVG（0.2×–10×），不影响页面其他区域（capture phase 拦截全局 wheel）
- **拖拽平移** → 按住左键拖动，光标显示 grab/grabbing；拖拽后的 click 不会误触关闭
- **Esc / 点背景** → 关闭；下次打开重置缩放和位移
- 同样逻辑修复了图片灯箱默认尺寸过小的问题（min-width: 600px）

实现要点：
- `onMermaidClick` 检测 `.milkdown-code-block .preview svg` 点击，克隆 SVG 并去掉 Mermaid 硬编码的 `width`/`height` 属性，让 CSS 自由控制尺寸
- `zoom` state 从 `null|string` 扩展为 `null|{type:'img',src}|{type:'svg',html}`，图片灯箱路径不变
- scale/translate/contentRef 三个 ref 直接在事件回调中写入，避免拖拽每帧触发 React re-render

---

## 4. Docker Windows NSIS 打包流水线

**痛点**：在 Linux CI / macOS 上无法直接打包 Windows exe。

```bash
docker build -f Dockerfile.win -t horsemd-builder-win .
docker run --rm -v "$PWD/dist-linux:/output" horsemd-builder-win
# 产物：dist-linux/HorseMD-Setup-<version>.exe
```

- `Dockerfile.win` — `node:18-bookworm` + wine32/wine64 + nsis
- `docker-entrypoint-win.sh` — electron-vite build → electron-builder --win nsis

---

## 提交历史

```
chore: add dist-linux/ to .gitignore
build(linux): add Docker-based deb packaging pipeline
build(linux): configure electron-builder deb target and installer scripts
fix(linux): taskbar icon, WM_CLASS, .md association, and zoom support
feat(editor): fullscreen lightbox for Mermaid diagrams with pan and zoom
build(win): add Docker-based Windows NSIS packaging pipeline
```