### PR TITLE
Add 'Close to the Right' option in tab context menu

### DIFF
--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -372,6 +372,7 @@ export default function App() {
     updateContent,
     closeTab,
     closeOthers,
+    closeRight,
     renameTabFile,
     commitTabRename,
     duplicateTabFile,
@@ -665,6 +666,7 @@ export default function App() {
         onClose={closeTab}
         onNew={newTab}
         onCloseOthers={closeOthers}
+        onCloseRight={closeRight}
         onOpenRight={openRight}
         onRename={renameTabFile}
         onDuplicate={duplicateTabFile}

--- a/src/renderer/src/components/Tabs.jsx
+++ b/src/renderer/src/components/Tabs.jsx
@@ -13,6 +13,7 @@ export default function Tabs({
   onClose,
   onNew,
   onCloseOthers,
+  onCloseRight,
   onOpenRight,
   onRename,
   onDuplicate,
@@ -142,6 +143,7 @@ export default function Tabs({
             {(() => {
               const tab = menu.tab
               const hasPath = !!tab.path
+              const tabIdx = tabs.findIndex((t) => t.id === tab.id)
               const noPathTip = !hasPath ? t('tab.noPath') : undefined
               const run = (fn) => () => { fn(); setMenu(null) }
               return (
@@ -181,6 +183,11 @@ export default function Tabs({
                   <button className="tab-menu-item" onClick={run(() => onClose(tab.id))}>
                     {t('tab.close')}
                   </button>
+                  {onCloseRight && tabIdx < tabs.length - 1 && (
+                    <button className="tab-menu-item" onClick={run(() => onCloseRight(tab.id))}>
+                      {t('tab.closeRight')}
+                    </button>
+                  )}
                   {onCloseOthers && tabs.length > 1 && (
                     <button className="tab-menu-item" onClick={run(() => onCloseOthers(tab.id))}>
                       {t('tab.closeOthers')}

--- a/src/renderer/src/components/shell/Topbar.jsx
+++ b/src/renderer/src/components/shell/Topbar.jsx
@@ -19,6 +19,7 @@ export default function Topbar({
   onClose,
   onNew,
   onCloseOthers,
+  onCloseRight,
   onOpenRight,
   onRename,
   onDuplicate,
@@ -50,6 +51,7 @@ export default function Topbar({
         onClose={onClose}
         onNew={onNew}
         onCloseOthers={onCloseOthers}
+        onCloseRight={onCloseRight}
         onOpenRight={onOpenRight}
         onRename={onRename}
         onDuplicate={onDuplicate}

--- a/src/renderer/src/hooks/useFileOps.js
+++ b/src/renderer/src/hooks/useFileOps.js
@@ -298,6 +298,31 @@ export function useFileOps({
     })
   }, [commitAllLive, setTabs, setActiveId, setSplitId, liveTimersRef, liveContentRef, tRef])
 
+  // Close all tabs to the right of `keepId` (from the tab right-click menu).
+  const closeRight = useCallback((keepId) => {
+    commitAllLive()
+    setTabs((prev) => {
+      const idx = prev.findIndex((t) => t.id === keepId)
+      if (idx === -1) return prev
+      const right = prev.slice(idx + 1)
+      if (right.length === 0) return prev
+      const firstDirty = right.find((t) => t.content !== t.savedContent)
+      if (firstDirty && !window.confirm(tRef.current('confirm.closeUnsaved', { name: firstDirty.title }))) {
+        return prev
+      }
+      for (const t of right) {
+        const timer = liveTimersRef.current.get(t.id)
+        if (timer) clearTimeout(timer)
+        liveTimersRef.current.delete(t.id)
+        liveContentRef.current.delete(t.id)
+      }
+      const rightIds = new Set(right.map((t) => t.id))
+      setActiveId((cur) => (rightIds.has(cur) ? keepId : cur))
+      setSplitId(null)
+      return prev.slice(0, idx + 1)
+    })
+  }, [commitAllLive, setTabs, setActiveId, setSplitId, liveTimersRef, liveContentRef, tRef])
+
   const writeTab = useCallback(async (tab, targetPath) => {
     try {
       // Move pasted images (base64 blobs / global paste-folder files) into the
@@ -506,6 +531,7 @@ export function useFileOps({
     updateContent,
     closeTab,
     closeOthers,
+    closeRight,
     renameTabFile,
     commitTabRename,
     duplicateTabFile,

--- a/src/renderer/src/i18n.jsx
+++ b/src/renderer/src/i18n.jsx
@@ -619,6 +619,7 @@ export const STRINGS = {
     'tab.reveal': '打开所在文件夹',
     'tab.openRight': '在右侧分屏打开',
     'tab.close': '关闭',
+    'tab.closeRight': '关闭右侧',
     'tab.closeOthers': '关闭其他',
     'tab.noPath': '未保存的文件，请先保存',
 


### PR DESCRIPTION
Add a 'Close to the Right' item in the tab right-click menu, positioned above 'Close Others'. Only shows when there are tabs to the right of the right-clicked tab.

- useFileOps: add closeRight() — closes all tabs right of the anchor tab, with unsaved-change confirmation and live-edit cleanup
- Tabs: add onCloseRight prop and menu item (tabIdx < length - 1)
- App: wire closeRight from useFileOps to <Tabs>
- i18n: add tab.closeRight (en: 'Close to the Right', zh: '关闭右侧')