### PR TITLE
Fixes #50: source-mode Enter key jumps viewport upward

### DIFF
--- a/src/renderer/src/components/shell/EditorArea.jsx
+++ b/src/renderer/src/components/shell/EditorArea.jsx
@@ -110,6 +110,22 @@ export default function EditorArea({
               style={{ order, flex: paneFlex }}
               onFocus={onPaneFocus}
               onMouseDown={onPaneFocus}
+              onKeyDown={(e) => {
+                // The textarea has padding-bottom: 60vh (to match the rich
+                // editor's scroll-space). This shrinks the browser's "visible
+                // caret area" to ~clientHeight − 60vh, so the native
+                // caret-scroll-on-Enter overcorrects and jumps the viewport.
+                // Save scrollTop on Enter and restore it (via rAF, after the
+                // browser's scroll) when the jump is excessive.
+                if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+                  const el = e.target
+                  const saved = el.scrollTop
+                  requestAnimationFrame(() => {
+                    const delta = el.scrollTop - saved
+                    if (delta < -50 || delta > 50) el.scrollTop = saved
+                  })
+                }
+              }}
               onChange={(e) => {
                 // Uncontrolled: stash the edit and debounce-commit it, so
                 // typing never re-renders App or re-sets a multi-MB value per


### PR DESCRIPTION
The source-mode <textarea> has padding-bottom: 60vh (matching the rich editor's scroll-space). This shrinks the browser's effective caret-visible area to ~clientHeight - 60vh (e.g. 754 - 492 = 262px on a typical window). When Enter is pressed, the browser's native caret-scroll-on-Enter thinks the cursor is outside this tiny visible band and overcorrects, jumping scrollTop by thousands of pixels (observed: -2900px).

Add an onKeyDown handler on the textarea that saves scrollTop before Enter, then restores it (via requestAnimationFrame, after the browser's scroll) when the delta exceeds ±50px. Small adjustments (cursor near the visible bottom edge) are allowed; only the excessive 60vh-induced jumps are suppressed.