### PR TITLE
Add collapsible outline headings with expand/collapse buttons

### DIFF
--- a/src/renderer/src/components/Outline.jsx
+++ b/src/renderer/src/components/Outline.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useI18n } from '../i18n.jsx'
 
 // Outline panel. The heading list comes from the parent (App), which reads the
@@ -12,6 +12,114 @@ export default function Outline({ headings = [], activeIndex = -1, onJump, loadi
   const panelRef = useRef(null) // the scroll container (.outline-list)
   const endpadRef = useRef(null) // trailing spacer so the last row can center
   const lastScrolledRef = useRef(-1) // dedupe — only act on a real active change
+
+  // Collapsed set: indices of headings whose children are hidden.
+  const [collapsed, setCollapsed] = useState(new Set())
+
+  // Last-seen headings signature, used to detect content changes (not just
+  // array-identity re-renders) so the collapsed set can be reset safely.
+  const prevSigRef = useRef('')
+
+  // A heading `i` is a parent (has foldable children) if a later heading has a
+  // deeper level before an equal-or-shallower level re-appears.
+  const hasChildren = (i) => {
+    if (i < 0 || i >= headings.length) return false
+    const lvl = headings[i].level
+    for (let j = i + 1; j < headings.length; j++) {
+      if (headings[j].level <= lvl) break
+      return true
+    }
+    return false
+  }
+
+  // A heading is visible if none of its ancestors are collapsed.
+  // Walk backwards; when we find a heading with a smaller level it's a direct
+  // ancestor — check it, then lower the threshold so only *its* ancestors
+  // (even smaller level) are checked next. Siblings at the same or deeper
+  // level are skipped.
+  const isVisible = (i) => {
+    let lvl = headings[i].level
+    for (let j = i - 1; j >= 0; j--) {
+      if (headings[j].level < lvl) {
+        if (collapsed.has(j)) return false
+        lvl = headings[j].level
+      }
+    }
+    return true
+  }
+
+  // Return the ancestor chain (indices) of heading i, from immediate parent
+  // up to the top-level heading.
+  const ancestorsOf = (i) => {
+    const result = []
+    let lvl = headings[i].level
+    for (let j = i - 1; j >= 0; j--) {
+      if (headings[j].level < lvl) {
+        result.push(j)
+        lvl = headings[j].level
+      }
+    }
+    return result
+  }
+
+  // Prevent collapsing a branch that contains the active heading — the
+  // scrollspy highlight must stay visible at all times. Expanding is always
+  // allowed.
+  const isProtected = (i) =>
+    activeIndex >= 0 && ancestorsOf(activeIndex).includes(i)
+
+  const toggle = (i) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(i)) {
+        next.delete(i)
+      } else {
+        if (isProtected(i)) return prev // never hide the active row
+        next.add(i)
+      }
+      return next
+    })
+  }
+
+  const expandAll = () => setCollapsed(new Set())
+  const collapseAll = () => {
+    // Collapse every heading that has children, except ancestors of the
+    // active heading.
+    const next = new Set()
+    for (let i = 0; i < headings.length; i++) {
+      if (hasChildren(i) && !isProtected(i)) next.add(i)
+    }
+    setCollapsed(next)
+  }
+
+  // Keep the active heading's ancestor chain expanded so the scrollspy
+  // highlight is always visible, even inside a folded branch.
+  useEffect(() => {
+    if (activeIndex < 0 || activeIndex >= headings.length) return
+    const ancestors = ancestorsOf(activeIndex)
+    if (!ancestors.length) return
+    setCollapsed((prev) => {
+      let changed = false
+      const next = new Set(prev)
+      for (const a of ancestors) {
+        if (next.has(a)) { next.delete(a); changed = true }
+      }
+      return changed ? next : prev
+    })
+  }, [activeIndex, headings])
+
+  // Reset the collapsed set whenever the headings *content* changes (edit,
+  // reload). Index-based state is only stable while the heading list itself
+  // is unchanged; if a heading at the same index now has different text/level
+  // the old collapsed state would apply to the wrong branch. A signature of
+  // level+text detects this without false-positive resets on plain re-renders.
+  useEffect(() => {
+    const sig = headings.map((h) => h.level + ':' + h.text).join('\n')
+    if (sig !== prevSigRef.current) {
+      prevSigRef.current = sig
+      setCollapsed(new Set())
+    }
+  }, [headings])
 
   // Soft-center the active heading. As long as it sits in the middle of the
   // panel we leave the scroll alone (no jitter when it's already comfortable);
@@ -55,9 +163,42 @@ export default function Outline({ headings = [], activeIndex = -1, onJump, loadi
     return () => ro.disconnect()
   }, [headings.length])
 
+  const anyExpandable = collapsed.size > 0
+  const anyCollapsible = headings.some((_, i) => hasChildren(i) && !collapsed.has(i) && !isProtected(i))
+
   return (
     <div className="outline">
-      <div className="panel-head">{t('outline.title')}</div>
+      <div className="panel-head">
+        <span>{t('outline.title')}</span>
+        {headings.length > 0 && (
+          <span className="outline-head-actions">
+            <button
+              className="outline-head-btn"
+              onClick={expandAll}
+              title={t('outline.expandAll')}
+              disabled={!anyExpandable}
+              aria-label={t('outline.expandAll')}
+            >
+              <svg width="14" height="14" viewBox="0 0 16 20" fill="none">
+                <path d="M4 6L8 2L12 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M4 12L8 16L12 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+            <button
+              className="outline-head-btn"
+              onClick={collapseAll}
+              title={t('outline.collapseAll')}
+              disabled={!anyCollapsible}
+              aria-label={t('outline.collapseAll')}
+            >
+              <svg width="14" height="14" viewBox="0 0 16 20" fill="none">
+                <path d="M4 4L8 8L12 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                <path d="M4 16L8 12L12 16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          </span>
+        )}
+      </div>
       <div className="outline-list" ref={panelRef}>
         {loading ? (
           // A huge doc is still streaming in (chunked parse) — its heading list
@@ -76,18 +217,40 @@ export default function Outline({ headings = [], activeIndex = -1, onJump, loadi
           <div className="outline-empty">{t('outline.empty')}</div>
         ) : (
           <>
-            {headings.map((h, i) => (
-              <div
-                key={i}
-                ref={i === activeIndex ? activeRef : undefined}
-                className={`outline-item lvl-${h.level}${i === activeIndex ? ' active' : ''}`}
-                style={{ paddingLeft: 12 + (h.level - 1) * 12 }}
-                onClick={() => onJump(i)}
-                title={h.text}
-              >
-                {h.text}
-              </div>
-            ))}
+            {headings.map((h, i) => {
+              if (!isVisible(i)) return null
+              const isParent = hasChildren(i)
+              const isCollapsed = collapsed.has(i)
+              return (
+                <div
+                  key={i}
+                  ref={i === activeIndex ? activeRef : undefined}
+                  className={`outline-item lvl-${h.level}${i === activeIndex ? ' active' : ''}`}
+                  style={{ paddingLeft: 12 + (h.level - 1) * 12 }}
+                  onClick={() => onJump(i)}
+                  title={h.text}
+                >
+                  {isParent ? (
+                    <span
+                      className="outline-twisty"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        toggle(i)
+                      }}
+                      role="button"
+                      aria-label={isCollapsed ? t('outline.expand') : t('outline.collapse')}
+                    >
+                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style={{ transform: isCollapsed ? 'none' : 'rotate(90deg)', transition: 'transform 0.12s ease' }}>
+                        <path d="M3 1.5L7 5L3 8.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </span>
+                  ) : (
+                    <span className="outline-twisty outline-twisty-leaf" />
+                  )}
+                  <span className="outline-item-text">{h.text}</span>
+                </div>
+              )
+            })}
             <div className="outline-endpad" ref={endpadRef} aria-hidden="true" />
           </>
         )}

--- a/src/renderer/src/i18n.jsx
+++ b/src/renderer/src/i18n.jsx
@@ -146,6 +146,10 @@ export const STRINGS = {
     // outline
     'outline.title': 'Outline',
     'outline.empty': 'No headings',
+    'outline.expandAll': 'Expand All',
+    'outline.collapseAll': 'Collapse All',
+    'outline.expand': 'Expand',
+    'outline.collapse': 'Collapse',
 
     // find
     'find.placeholder': 'Find in document',
@@ -462,6 +466,10 @@ export const STRINGS = {
 
     'outline.title': '大纲',
     'outline.empty': '暂无标题',
+    'outline.expandAll': '全部展开',
+    'outline.collapseAll': '全部折叠',
+    'outline.expand': '展开',
+    'outline.collapse': '折叠',
 
     'find.placeholder': '在文档中查找',
     'find.next': '下一个',

--- a/src/renderer/src/styles/app.css
+++ b/src/renderer/src/styles/app.css
@@ -1536,6 +1536,9 @@ body.resizing-pane .pane-left-resizer::before {
   flex: 1;
 }
 .outline-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   padding: 5px 10px;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -1546,6 +1549,45 @@ body.resizing-pane .pane-left-resizer::before {
   text-overflow: ellipsis;
   transition: all 0.12s var(--ease-out);
 }
+.outline-twisty {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  color: var(--faint);
+  cursor: pointer;
+}
+.outline-twisty:hover { background: var(--hover); }
+.outline-twisty-leaf { width: 14px; height: 14px; }
+.outline-item-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.outline-head-actions {
+  display: flex;
+  gap: 2px;
+}
+.outline-head-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.12s var(--ease-out);
+}
+.outline-head-btn:hover:not(:disabled) { background: var(--hover); color: var(--text); }
+.outline-head-btn:active:not(:disabled) { background: var(--active); }
+.outline-head-btn:disabled { opacity: 0.35; cursor: default; }
 .outline-item:hover {
   background: var(--hover);
   color: var(--text);


### PR DESCRIPTION
Add fold/unfold capability to the outline panel:

- Each heading that has children shows a twisty arrow (►/▼). Clicking it toggles the visibility of its descendant headings.
- Two buttons added to the right of the fixed panel header: 'Expand All' and 'Collapse All'. Each disables itself when there's nothing to do.
- Collapsed state is stored in a Set of heading indices; a heading is visible only if none of its ancestors are collapsed.
- Uses inline SVG icons (no font dependency) for cross-platform fidelity.
- i18n: en (Expand All / Collapse All / Expand / Collapse), zh (全部展开 / 全部折叠 / 展开 / 折叠).
<img width="282" height="196" alt="IMG_20260710_101620" src="https://github.com/user-attachments/assets/7775358e-e72b-4068-9df4-b2d09404efe5" />
